### PR TITLE
Added detailed-notifier option (enabled by default)

### DIFF
--- a/src/main/java/com/bgsoftware/wildchests/handlers/SettingsHandler.java
+++ b/src/main/java/com/bgsoftware/wildchests/handlers/SettingsHandler.java
@@ -26,6 +26,7 @@ import java.util.Map;
 public final class SettingsHandler {
 
     public final long notifyInterval;
+    public final boolean detailedNotifier;
     public final boolean confirmGUI;
     public final String sellCommand;
     public final boolean sellFormat;
@@ -48,6 +49,7 @@ public final class SettingsHandler {
         cfg.syncWithConfig(file, plugin.getResource("config.yml"), "chests");
 
         notifyInterval = cfg.getLong("notifier-interval", 12000);
+        detailedNotifier = cfg.getBoolean("detailed-notifier", true);
         confirmGUI = cfg.getBoolean("confirm-gui", false);
         sellCommand = cfg.getString("sell-command", "");
         sellFormat = cfg.getBoolean("sell-format", false);

--- a/src/main/java/com/bgsoftware/wildchests/task/NotifierTask.java
+++ b/src/main/java/com/bgsoftware/wildchests/task/NotifierTask.java
@@ -47,9 +47,10 @@ public final class NotifierTask extends BukkitRunnable {
                 BigDecimal totalEarned = BigDecimal.ZERO;
 
                 for(TransactionDetails item : itemsSold){
-                    Locale.SOLD_CHEST_LINE.send(offlinePlayer.getPlayer(), item.amount, item.itemStack.getType(),
-                            plugin.getSettings().sellFormat ? StringUtils.fancyFormat(item.amountEarned) :
-                                    StringUtils.format(item.amountEarned));
+                    if(plugin.getSettings().detailedNotifier)
+                        Locale.SOLD_CHEST_LINE.send(offlinePlayer.getPlayer(), item.amount, item.itemStack.getType(),
+                                plugin.getSettings().sellFormat ? StringUtils.fancyFormat(item.amountEarned) :
+                                        StringUtils.format(item.amountEarned));
                     totalEarned  = totalEarned.add(item.amountEarned);
                 }
 
@@ -65,7 +66,8 @@ public final class NotifierTask extends BukkitRunnable {
                 int totalCrafted = 0;
 
                 for(CraftingDetails item : itemsCrafted){
-                    Locale.CRAFTED_ITEMS_LINE.send(offlinePlayer.getPlayer(), item.amount, item.itemStack.getType());
+                    if(plugin.getSettings().detailedNotifier)
+                        Locale.CRAFTED_ITEMS_LINE.send(offlinePlayer.getPlayer(), item.amount, item.itemStack.getType());
                     totalCrafted += item.amount;
                 }
 

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -10,7 +10,6 @@
 notifier-interval: 12000
 
 # When enabled there will be a list of items that has been sold and crafted.
-# The value above must be larger than 0.
 detailed-notifier: true
 
 # When enabled, a gui will be popped to confirm chest expand purchase. Otherwise, it will be done in chat.

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,6 +9,10 @@
 # Set 0 to disable this feature.
 notifier-interval: 12000
 
+# When enabled there will be a list of items that has been sold and crafted.
+# The value above must be larger than 0.
+detailed-notifier: true
+
 # When enabled, a gui will be popped to confirm chest expand purchase. Otherwise, it will be done in chat.
 confirm-gui: false
 


### PR DESCRIPTION
Hello Ome_R!

I added an option that many players requested on my server and I want to do a pull request!
The option I have added is a detailed notifier, that allows to enable the list of items that has been sold or crafted if a notification is shown.
It is enabled by default, so to the users of WildChests nothing will be changed at all.

(I made a new pull request as I missed up the last one pretty match)