### PR TITLE
Fix `itemsRemoved` value is not updated

### DIFF
--- a/src/main/java/com/bgsoftware/wildchests/objects/chests/WChest.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/chests/WChest.java
@@ -161,6 +161,7 @@ public abstract class WChest extends DatabaseObject implements Chest {
             ItemStack cloned = itemStack.clone();
             cloned.setAmount(toRemove);
             page.removeItem(cloned);
+            itemsRemoved += toRemove;
         }
     }
 


### PR DESCRIPTION
As the title said, if the value is not updated. It will remove item from the rest of the pages although it has already reached the amount.

For example: 

```java
removeItem(1, new ItemStack(MATERIAL.SAND))
```
Due to the `itemsRemoved` value is not updated, it will continue removing 1 sand from the rest of pages until `i < pages.length` returns false