### PR TITLE
Fix sync chunk loads

### DIFF
--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/NMSAdapterImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/NMSAdapterImpl.java
@@ -12,6 +12,7 @@ import net.minecraft.server.v1_12_R1.NBTTagCompound;
 import net.minecraft.server.v1_12_R1.NBTTagList;
 import net.minecraft.server.v1_12_R1.TileEntityChest;
 import net.minecraft.server.v1_12_R1.World;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_12_R1.CraftWorld;
@@ -27,6 +28,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings({"unused", "ConstantConditions"})
 public final class NMSAdapterImpl implements NMSAdapter {
@@ -173,6 +175,11 @@ public final class NMSAdapterImpl implements NMSAdapter {
         EntityHuman entityHuman = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         entityHuman.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/NMSAdapterImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/NMSAdapterImpl.java
@@ -13,6 +13,7 @@ import net.minecraft.server.v1_16_R3.NBTTagCompound;
 import net.minecraft.server.v1_16_R3.NBTTagList;
 import net.minecraft.server.v1_16_R3.TileEntityChest;
 import net.minecraft.server.v1_16_R3.World;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_16_R3.CraftWorld;
@@ -28,6 +29,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings({"unused", "ConstantConditions"})
 public final class NMSAdapterImpl implements NMSAdapter {
@@ -175,6 +177,11 @@ public final class NMSAdapterImpl implements NMSAdapter {
         EntityHuman entityHuman = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         entityHuman.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {

--- a/NMS/v1_17/src/main/java/com/bgsoftware/wildchests/nms/v1_17/NMSAdapterImpl.java
+++ b/NMS/v1_17/src/main/java/com/bgsoftware/wildchests/nms/v1_17/NMSAdapterImpl.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -36,6 +37,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -175,6 +177,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_18/src/main/java/com/bgsoftware/wildchests/nms/v1_18/NMSAdapterImpl.java
+++ b/NMS/v1_18/src/main/java/com/bgsoftware/wildchests/nms/v1_18/NMSAdapterImpl.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -36,6 +37,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -175,6 +177,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_19/src/main/java/com/bgsoftware/wildchests/nms/v1_19/NMSAdapterImpl.java
+++ b/NMS/v1_19/src/main/java/com/bgsoftware/wildchests/nms/v1_19/NMSAdapterImpl.java
@@ -17,6 +17,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -36,6 +37,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -175,6 +177,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_20_3/src/main/java/com/bgsoftware/wildchests/nms/v1_20_3/NMSAdapterImpl.java
+++ b/NMS/v1_20_3/src/main/java/com/bgsoftware/wildchests/nms/v1_20_3/NMSAdapterImpl.java
@@ -18,6 +18,7 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -37,6 +38,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -176,6 +178,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_20_4/src/main/java/com/bgsoftware/wildchests/nms/v1_20_4/NMSAdapterImpl.java
+++ b/NMS/v1_20_4/src/main/java/com/bgsoftware/wildchests/nms/v1_20_4/NMSAdapterImpl.java
@@ -21,6 +21,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -40,6 +41,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -184,6 +186,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_21/src/main/java/com/bgsoftware/wildchests/nms/v1_21/NMSAdapterImpl.java
+++ b/NMS/v1_21/src/main/java/com/bgsoftware/wildchests/nms/v1_21/NMSAdapterImpl.java
@@ -22,6 +22,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -40,6 +41,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -186,6 +188,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_21_3/src/main/java/com/bgsoftware/wildchests/nms/v1_21_3/NMSAdapterImpl.java
+++ b/NMS/v1_21_3/src/main/java/com/bgsoftware/wildchests/nms/v1_21_3/NMSAdapterImpl.java
@@ -22,6 +22,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -40,6 +41,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -186,6 +188,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_21_4/src/main/java/com/bgsoftware/wildchests/nms/v1_21_4/NMSAdapterImpl.java
+++ b/NMS/v1_21_4/src/main/java/com/bgsoftware/wildchests/nms/v1_21_4/NMSAdapterImpl.java
@@ -22,6 +22,7 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.item.component.CustomData;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.World;
@@ -40,6 +41,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 public final class NMSAdapterImpl implements NMSAdapter {
 
@@ -186,6 +188,16 @@ public final class NMSAdapterImpl implements NMSAdapter {
         Player player = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         player.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        try {
+            return location.getWorld().getChunkAtAsync(location);
+        } catch (Throwable ignored) {
+        }
+
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack bukkitItem, String key, String value) {

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/NMSAdapterImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/NMSAdapterImpl.java
@@ -12,6 +12,7 @@ import net.minecraft.server.v1_8_R3.NBTTagCompound;
 import net.minecraft.server.v1_8_R3.NBTTagList;
 import net.minecraft.server.v1_8_R3.TileEntityChest;
 import net.minecraft.server.v1_8_R3.World;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.craftbukkit.v1_8_R3.CraftWorld;
@@ -27,6 +28,7 @@ import java.io.DataOutput;
 import java.io.DataOutputStream;
 import java.math.BigInteger;
 import java.util.Base64;
+import java.util.concurrent.CompletableFuture;
 
 @SuppressWarnings("unused")
 public final class NMSAdapterImpl implements NMSAdapter {
@@ -170,6 +172,11 @@ public final class NMSAdapterImpl implements NMSAdapter {
         EntityHuman entityHuman = ((CraftHumanEntity) humanEntity).getHandle();
         ItemStack itemStack = CraftItemStack.asNMSCopy(bukkitItem);
         entityHuman.drop(itemStack, false);
+    }
+
+    @Override
+    public CompletableFuture<Chunk> getChunk(Location location) {
+        return CompletableFuture.completedFuture(location.getChunk());
     }
 
     private org.bukkit.inventory.ItemStack setItemTag(org.bukkit.inventory.ItemStack itemStack, String key, String value) {

--- a/src/main/java/com/bgsoftware/wildchests/listeners/ChunksListener.java
+++ b/src/main/java/com/bgsoftware/wildchests/listeners/ChunksListener.java
@@ -43,15 +43,17 @@ public final class ChunksListener implements Listener {
     private static void loadChestsForChunk(WildChestsPlugin plugin, Chunk chunk) {
         plugin.getChestsManager().getChests(chunk).forEach(chest -> {
             Location location = chest.getLocation();
-            Material blockType = location.getBlock().getType();
-            if (blockType != Material.CHEST) {
-                WildChestsPlugin.log("Loading chunk " + chunk.getX() + ", " + chunk.getX() + " but found a chest not " +
-                        "associated with a chest block but " + blockType + " at " + location.getWorld().getName() + ", " +
-                        location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ());
-                chest.remove();
-            } else {
-                ((WChest) chest).onChunkLoad();
-            }
+            plugin.getNMSAdapter().getChunk(location).thenAccept(loadedChunk -> {
+                Material blockType = location.getBlock().getType();
+                if (blockType != Material.CHEST) {
+                    WildChestsPlugin.log("Loading chunk " + chunk.getX() + ", " + chunk.getX() + " but found a chest not " +
+                            "associated with a chest block but " + blockType + " at " + location.getWorld().getName() + ", " +
+                            location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ());
+                    chest.remove();
+                } else {
+                    ((WChest) chest).onChunkLoad();
+                }
+            });
         });
     }
 

--- a/src/main/java/com/bgsoftware/wildchests/nms/NMSAdapter.java
+++ b/src/main/java/com/bgsoftware/wildchests/nms/NMSAdapter.java
@@ -2,12 +2,14 @@ package com.bgsoftware.wildchests.nms;
 
 import com.bgsoftware.wildchests.api.objects.ChestType;
 import com.bgsoftware.wildchests.objects.inventory.InventoryHolder;
+import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nullable;
+import java.util.concurrent.CompletableFuture;
 
 public interface NMSAdapter {
 
@@ -29,5 +31,7 @@ public interface NMSAdapter {
     String getChestName(ItemStack itemStack);
 
     void dropItemAsPlayer(HumanEntity humanEntity, ItemStack bukkitItem);
+
+    CompletableFuture<Chunk> getChunk(Location location);
 
 }


### PR DESCRIPTION
This PR uses paper's `getChunkAtAsync` when available and prevents sync chunk loads when verifying block materials
![image](https://github.com/user-attachments/assets/f36e719f-99bd-4823-961d-4f1b2004ddf3)
