### PR TITLE
Add configurable container appearances

### DIFF
--- a/API/src/main/java/com/bgsoftware/wildchests/api/objects/data/ChestData.java
+++ b/API/src/main/java/com/bgsoftware/wildchests/api/objects/data/ChestData.java
@@ -2,6 +2,7 @@ package com.bgsoftware.wildchests.api.objects.data;
 
 import com.bgsoftware.wildchests.api.key.Key;
 import com.bgsoftware.wildchests.api.objects.DepositMethod;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 import com.bgsoftware.wildchests.api.objects.ChestType;
@@ -31,6 +32,11 @@ public interface ChestData {
      * Get the type of the chest.
      */
     ChestType getChestType();
+
+    /**
+     * Get the block material used to place this chest.
+     */
+    Material getContainerMaterial();
 
     /**
      * Get the default size for pages for the chest.
@@ -138,6 +144,12 @@ public interface ChestData {
      * @param size The size to set.
      */
     void setDefaultSize(int size);
+
+    /**
+     * Set the block material used to place this chest.
+     * @param containerMaterial The material to set.
+     */
+    void setContainerMaterial(Material containerMaterial);
 
     /**
      * Set the default title of the pages.

--- a/NMS/src/main/templates/AbstractNMSInventory.java.template
+++ b/NMS/src/main/templates/AbstractNMSInventory.java.template
@@ -5,12 +5,14 @@ import com.bgsoftware.wildchests.api.objects.chests.Chest;
 import com.bgsoftware.wildchests.api.objects.chests.StorageChest;
 import com.bgsoftware.wildchests.nms.NMSInventory;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.CraftWildInventoryImpl;
+import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildBarrelBlockEntity;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildChestBlockEntity;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildChestMenu;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildContainer;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildContainerItemImpl;
 import com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory.WildHopperMenu;
 import com.bgsoftware.wildchests.objects.chests.WChest;
+import com.bgsoftware.wildchests.objects.containers.TileEntityContainer;
 import com.bgsoftware.wildchests.objects.inventory.CraftWildInventory;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.protocol.game.ClientboundOpenScreenPacket;
@@ -34,8 +36,14 @@ import org.bukkit.entity.Player;
 
 public abstract class AbstractNMSInventory implements NMSInventory {
 
+    private static final Material BARREL = Material.matchMaterial("BARREL");
     private static final ReflectMethod<TickingBlockEntity> CREATE_TICKING_BLOCK = new ReflectMethod<>(
             LevelChunk.class, 1, BlockEntity.class, BlockEntityTicker.class);
+
+    @Override
+    public boolean isContainerMaterialSupported(Material material) {
+        return material == Material.CHEST || material == Material.TRAPPED_CHEST || material == BARREL;
+    }
 
     @Override
     public void updateTileEntity(Chest chest) {
@@ -49,14 +57,19 @@ public abstract class AbstractNMSInventory implements NMSInventory {
         BlockPos blockPos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         BlockEntity blockEntity = serverLevel.getBlockEntity(blockPos);
 
-        if (blockEntity instanceof WildChestBlockEntity wildChestBlockEntity) {
-            ((WChest) chest).setTileEntityContainer(wildChestBlockEntity);
+        // A tile entity can outlive a removed or reloaded chest briefly. Never attach a chest to a
+        // tile entity created for another model instance at the same position.
+        if (blockEntity instanceof TileEntityContainer tileEntityContainer && tileEntityContainer.isOwner(chest)) {
+            ((WChest) chest).setTileEntityContainer(tileEntityContainer);
         } else {
-            WildChestBlockEntity wildChestBlockEntity = new WildChestBlockEntity(chest, serverLevel, blockPos);
+            BlockEntity wildChestBlockEntity = ((WChest) chest).getContainerMaterial() == BARREL ?
+                    new WildBarrelBlockEntity(chest, serverLevel, blockPos) :
+                    new WildChestBlockEntity(chest, serverLevel, blockPos);
             serverLevel.removeBlockEntity(blockPos);
             serverLevel.setBlockEntity(wildChestBlockEntity);
             LevelChunk levelChunk = serverLevel.getChunkAt(blockPos);
-            serverLevel.addBlockEntityTicker(CREATE_TICKING_BLOCK.invoke(levelChunk, wildChestBlockEntity, wildChestBlockEntity));
+            serverLevel.addBlockEntityTicker(CREATE_TICKING_BLOCK.invoke(levelChunk, wildChestBlockEntity,
+                    (BlockEntityTicker) wildChestBlockEntity));
         }
     }
 
@@ -71,7 +84,8 @@ public abstract class AbstractNMSInventory implements NMSInventory {
         ServerLevel serverLevel = ((CraftWorld) bukkitWorld).getHandle();
         BlockPos blockPos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
         BlockEntity blockEntity = serverLevel.getBlockEntity(blockPos);
-        if (blockEntity instanceof WildChestBlockEntity)
+        // Do not remove a replacement tile entity when a stale chest is being unloaded.
+        if (blockEntity instanceof TileEntityContainer tileEntityContainer && tileEntityContainer.isOwner(chest))
             serverLevel.removeBlockEntity(blockPos);
     }
 

--- a/NMS/src/main/templates/inventory/BaseNMSMenu.java.template
+++ b/NMS/src/main/templates/inventory/BaseNMSMenu.java.template
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory;
 
 import com.bgsoftware.wildchests.objects.chests.WChest;
+import com.bgsoftware.wildchests.objects.containers.TileEntityContainer;
 import com.bgsoftware.wildchests.scheduler.Scheduler;
 import net.minecraft.world.entity.player.Inventory;
 import net.minecraft.world.entity.player.Player;
@@ -40,7 +41,11 @@ public class BaseNMSMenu {
     }
 
     private void doRemoved(Player player) {
-        ((WildChestBlockEntity) ((WChest) inventory.chest).getTileEntityContainer()).stopOpen(player);
+        TileEntityContainer tileEntityContainer = ((WChest) inventory.chest).getTileEntityContainer();
+        // This runs on the owning region after scheduling, so the chest may have been replaced in
+        // the meantime. The common contract also avoids assuming the entity is always a chest.
+        if (tileEntityContainer != null && tileEntityContainer.isOwner(inventory.chest))
+            tileEntityContainer.closeContainer(player.getBukkitEntity());
     }
 
 }

--- a/NMS/src/main/templates/inventory/WildBarrelBlockEntity.java.template
+++ b/NMS/src/main/templates/inventory/WildBarrelBlockEntity.java.template
@@ -1,6 +1,5 @@
 package com.bgsoftware.wildchests.nms.${NMS_VERSION}.inventory;
 
-import com.bgsoftware.common.reflection.ReflectMethod;
 import com.bgsoftware.wildchests.WildChestsPlugin;
 import com.bgsoftware.wildchests.api.objects.chests.Chest;
 import com.bgsoftware.wildchests.api.objects.chests.StorageChest;
@@ -16,8 +15,6 @@ import net.minecraft.core.Direction;
 import net.minecraft.core.NonNullList;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.sounds.SoundEvent;
-import net.minecraft.sounds.SoundEvents;
 import net.minecraft.world.WorldlyContainer;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.entity.player.Inventory;
@@ -25,19 +22,13 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.inventory.AbstractContainerMenu;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.ChestBlock;
-import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BarrelBlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
-import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 import org.bukkit.Particle;
-import ${CRAFTBUKKIT_PACKAGE}.CraftParticle;
 import ${CRAFTBUKKIT_PACKAGE}.entity.CraftHumanEntity;
 import ${CRAFTBUKKIT_PACKAGE}.entity.CraftItem;
-import ${CRAFTBUKKIT_PACKAGE}.event.CraftEventFactory;
 import ${CRAFTBUKKIT_PACKAGE}.inventory.CraftItemStack;
 import ${CRAFTBUKKIT_PACKAGE}.util.CraftChatMessage;
 import org.bukkit.entity.HumanEntity;
@@ -46,33 +37,25 @@ import org.bukkit.entity.Item;
 import java.util.List;
 import java.util.Map;
 
-public class WildChestBlockEntity extends ChestBlockEntity implements
-        WorldlyContainer, TileEntityContainer, BlockEntityTicker<WildChestBlockEntity> {
+// Extending the native barrel entity is required because Minecraft validates an entity's type
+// against the placed block state when it is constructed.
+public class WildBarrelBlockEntity extends BarrelBlockEntity implements
+        WorldlyContainer, TileEntityContainer, BlockEntityTicker<WildBarrelBlockEntity> {
 
     private static final WildChestsPlugin plugin = WildChestsPlugin.getPlugin();
 
-    private final ChestBlockEntity chestBlockEntity;
     private final Chest chest;
-    protected final ServerLevel serverLevel;
     private final BlockPos blockPos;
-    private final boolean isTrappedChest;
-
     private short currentCooldown = ChestUtils.DEFAULT_COOLDOWN;
-    private int viewingCount = 0;
+    private AABB suctionItems;
+    private boolean autoCraftMode;
+    private boolean autoSellMode;
 
-    private AABB suctionItems = null;
-    private boolean autoCraftMode = false;
-    private boolean autoSellMode = false;
-
-    public WildChestBlockEntity(Chest chest, ServerLevel serverLevel, BlockPos blockPos) {
+    public WildBarrelBlockEntity(Chest chest, ServerLevel serverLevel, BlockPos blockPos) {
         super(blockPos, serverLevel.getBlockState(blockPos));
         this.chest = chest;
-        this.serverLevel = serverLevel;
         this.blockPos = blockPos;
         this.level = serverLevel;
-        BlockState blockState = getBlockState();
-        this.chestBlockEntity = new ChestBlockEntity(blockPos, blockState);
-        isTrappedChest = blockState.getBlock() == Blocks.TRAPPED_CHEST;
         ((WChest) chest).setTileEntityContainer(this);
         updateData();
     }
@@ -93,18 +76,19 @@ public class WildChestBlockEntity extends ChestBlockEntity implements
     }
 
     @Override
-    public void setItem(int i, ItemStack itemStack) {
-        ((WChest) chest).setItem(i, new WildContainerItemImpl(itemStack));
+    public void setItem(int slot, ItemStack itemStack) {
+        ((WChest) chest).setItem(slot, new WildContainerItemImpl(itemStack));
     }
 
     @Override
-    public ItemStack getItem(int i) {
-        return ((WildContainerItemImpl) ((WChest) chest).getWildItem(i)).getHandle();
+    public ItemStack getItem(int slot) {
+        return ((WildContainerItemImpl) ((WChest) chest).getWildItem(slot)).getHandle();
     }
 
     @Override
     public NonNullList<ItemStack> getContents() {
-        return TransformingNonNullList.transform(((WChest) chest).getWildContents(), ItemStack.EMPTY, WildContainerItemImpl::transform);
+        return TransformingNonNullList.transform(((WChest) chest).getWildContents(), ItemStack.EMPTY,
+                WildContainerItemImpl::transform);
     }
 
     @Override
@@ -117,96 +101,37 @@ public class WildChestBlockEntity extends ChestBlockEntity implements
 
     @Override
     public Component getDisplayName() {
-        return CraftChatMessage.fromStringOrNull(((com.bgsoftware.wildchests.objects.inventory.CraftWildInventory) chest.getPage(0)).getTitle());
-    }
-
-    @Override
-    public final void stopOpen(${CONTAINER_OPEN_PARAM_TYPE} containerUser) {
-        Player player;
-
-        try {
-            player = (Player) containerUser;
-        } catch (Throwable error) {
-            return;
-        }
-
-        CraftHumanEntity craftHumanEntity = player.getBukkitEntity();
-
-        this.transaction.remove(craftHumanEntity);
-
-        if (!player.isSpectator()) {
-            int oldPower = Math.max(0, Math.min(15, this.viewingCount));
-            this.viewingCount--;
-
-            if (isTrappedChest) {
-                int newPower = Math.max(0, Math.min(15, this.viewingCount));
-                if (oldPower != newPower) {
-                    CraftEventFactory.callRedstoneChange(this.serverLevel, this.blockPos, oldPower, newPower);
-                }
-            }
-
-            onOpen();
-            if (viewingCount <= 0)
-                playOpenSound(SoundEvents.CHEST_CLOSE);
-        }
+        return CraftChatMessage.fromStringOrNull(((com.bgsoftware.wildchests.objects.inventory.CraftWildInventory)
+                chest.getPage(0)).getTitle());
     }
 
     @Override
     public void startOpen(${CONTAINER_OPEN_PARAM_TYPE} containerUser) {
-        Player player;
+        if (containerUser instanceof Player)
+            this.transaction.add(((Player) containerUser).getBukkitEntity());
 
-        try {
-            player = (Player) containerUser;
-        } catch (Throwable error) {
-            return;
-        }
-
-        CraftHumanEntity craftHumanEntity = player.getBukkitEntity();
-
-        this.transaction.add(craftHumanEntity);
-
-        if (!player.isSpectator()) {
-            if (this.viewingCount < 0) {
-                this.viewingCount = 0;
-            }
-
-            int oldPower = Math.max(0, Math.min(15, this.viewingCount));
-            this.viewingCount++;
-
-            if (isTrappedChest) {
-                int newPower = Math.max(0, Math.min(15, this.viewingCount));
-                if (oldPower != newPower) {
-                    CraftEventFactory.callRedstoneChange(this.serverLevel, this.blockPos, oldPower, newPower);
-                }
-            }
-
-            onOpen();
-            if (viewingCount == 1)
-                playOpenSound(SoundEvents.CHEST_OPEN);
-        }
+        super.startOpen(containerUser);
     }
 
     @Override
-    public final void onOpen(CraftHumanEntity who) {
+    public void stopOpen(${CONTAINER_OPEN_PARAM_TYPE} containerUser) {
+        if (containerUser instanceof Player)
+            this.transaction.remove(((Player) containerUser).getBukkitEntity());
+
+        super.stopOpen(containerUser);
     }
 
     @Override
-    public final void onClose(CraftHumanEntity who) {
-    }
-
-    @Override
-    public void tick(Level level, BlockPos blockPos, BlockState blockState, WildChestBlockEntity blockEntity) {
+    public void tick(Level level, BlockPos blockPos, BlockState blockState, WildBarrelBlockEntity blockEntity) {
         ChestData chestData = chest.getData();
 
-        {
-            double x = blockPos.getX() + level.getRandom().nextFloat();
-            double y = blockPos.getY() + level.getRandom().nextFloat();
-            double z = blockPos.getZ() + level.getRandom().nextFloat();
-            for (String particle : chestData.getChestParticles()) {
-                try {
-                    sendParticlesInternal(Particle.valueOf(particle), x, y, z);
-                } catch (Exception ignored) {
-                }
+        double x = blockPos.getX() + level.getRandom().nextFloat();
+        double y = blockPos.getY() + level.getRandom().nextFloat();
+        double z = blockPos.getZ() + level.getRandom().nextFloat();
+        for (String particle : chestData.getChestParticles()) {
+            try {
+                level.getWorld().spawnParticle(Particle.valueOf(particle), x, y, z, 0, 0D, 0D, 0D, 1.0, null, false);
+            } catch (IllegalArgumentException ignored) {
             }
         }
 
@@ -221,18 +146,14 @@ public class WildChestBlockEntity extends ChestBlockEntity implements
 
         currentCooldown = ChestUtils.DEFAULT_COOLDOWN;
 
-        if (suctionItems != null) {
+        if (suctionItems != null)
             handleSuctionItems(chestData);
-        }
 
-        if (autoCraftMode) {
+        if (autoCraftMode)
             ChestUtils.tryCraftChest(chest);
-        }
 
-        if (autoSellMode) {
+        if (autoSellMode)
             ChestUtils.trySellChest(chest);
-        }
-
     }
 
     @Override
@@ -242,11 +163,7 @@ public class WildChestBlockEntity extends ChestBlockEntity implements
 
     @Override
     public int getViewingCount() {
-        this.openersCounter.getOpenerCount();
-        if (this.viewingCount < 0)
-            this.viewingCount = 0;
-
-        return viewingCount;
+        return this.openersCounter.getOpenerCount();
     }
 
     @Override
@@ -297,63 +214,32 @@ public class WildChestBlockEntity extends ChestBlockEntity implements
             ((StorageChest) chest).update();
     }
 
-    private void playOpenSound(SoundEvent soundEvent) {
-        ChestBlockEntity.playSound(this.serverLevel, this.blockPos, getBlockState(), soundEvent);
-    }
-
-    private void onOpen() {
-        Block block = getBlockState().getBlock();
-        if (block instanceof ChestBlock) {
-            if (!this.openersCounter.opened) {
-                this.serverLevel.blockEvent(this.blockPos, block, 1, this.viewingCount);
-            }
-
-            this.serverLevel.updateNeighborsAt(this.blockPos, block);
-        }
-    }
-
     private void handleSuctionItems(ChestData chestData) {
         List<ItemEntity> nearbyItems = level.getEntitiesOfClass(ItemEntity.class, suctionItems,
                 entityItem -> ChestUtils.SUCTION_PREDICATE.test((CraftItem) entityItem.getBukkitEntity(), chestData));
 
-        if (nearbyItems.isEmpty())
-            return;
-
         for (ItemEntity itemEntity : nearbyItems) {
             org.bukkit.inventory.ItemStack itemStack = CraftItemStack.asCraftMirror(itemEntity.getItem()).clone();
-
             Item item = (Item) itemEntity.getBukkitEntity();
-
             int actualItemCount = plugin.getProviders().getItemAmount(item);
-
             List<org.bukkit.inventory.ItemStack> suctionItems = ChestUtils.fixItemStackAmount(itemStack, actualItemCount);
-
             Map<Integer, org.bukkit.inventory.ItemStack> leftOvers = chest.addItems(
                     suctionItems.toArray(new org.bukkit.inventory.ItemStack[0]));
 
-            // We check that if there was any item that was added.
-            // If not, we can just do nothing.
             if (leftOvers.size() != suctionItems.size() ||
                     (leftOvers.size() == 1 && leftOvers.get(0).getAmount() != actualItemCount)) {
                 if (leftOvers.isEmpty()) {
-                    handleItemSuctionRemoval(itemEntity);
+                    level.getWorld().spawnParticle(Particle.CLOUD, itemEntity.getX(), itemEntity.getY(), itemEntity.getZ(),
+                            0, 0D, 0D, 0D, 1.0, null, false);
+                    itemEntity.discard();
                 } else {
                     int newStackAmount = 0;
-                    for (org.bukkit.inventory.ItemStack leftOverItem : leftOvers.values())
-                        newStackAmount += leftOverItem.getAmount();
+                    for (org.bukkit.inventory.ItemStack leftOver : leftOvers.values())
+                        newStackAmount += leftOver.getAmount();
                     plugin.getProviders().setItemAmount(item, newStackAmount);
                 }
             }
         }
-    }
-
-    private void handleItemSuctionRemoval(ItemEntity itemEntity) {
-        sendParticlesInternal(Particle.CLOUD, itemEntity.getX(), itemEntity.getY(), itemEntity.getZ());
-        itemEntity.discard();
-    }
-
-    private void sendParticlesInternal(Particle particle, double x, double y, double z) {
-        this.serverLevel.getWorld().spawnParticle(particle, x, y, z, 0, 0D, 0D, 0D, 1.0, null, false);
     }
 
 }

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/NMSInventoryImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/NMSInventoryImpl.java
@@ -43,7 +43,7 @@ public final class NMSInventoryImpl implements NMSInventory {
 
         TileEntityWildChest tileEntityWildChest;
 
-        if (tileEntity instanceof TileEntityWildChest) {
+        if (tileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) tileEntity).isOwner(chest)) {
             tileEntityWildChest = (TileEntityWildChest) tileEntity;
             ((WChest) chest).setTileEntityContainer(tileEntityWildChest);
         } else {
@@ -59,7 +59,7 @@ public final class NMSInventoryImpl implements NMSInventory {
         World world = ((CraftWorld) loc.getWorld()).getHandle();
         BlockPosition blockPosition = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
         TileEntity currentTileEntity = world.getTileEntity(blockPosition);
-        if (currentTileEntity instanceof TileEntityWildChest)
+        if (currentTileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) currentTileEntity).isOwner(chest))
             world.s(blockPosition);
     }
 

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/inventory/TileEntityWildChest.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildchests/nms/v1_12_R1/inventory/TileEntityWildChest.java
@@ -73,6 +73,16 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
     @Override
+    public boolean isOwner(Chest chest) {
+        return this.chest == chest;
+    }
+
+    @Override
+    public void closeContainer(HumanEntity humanEntity) {
+        closeContainer(((CraftHumanEntity) humanEntity).getHandle());
+    }
+
+    @Override
     protected NonNullList<ItemStack> q() {
         return getContents();
     }
@@ -217,9 +227,8 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
         if (--currentCooldown >= 0)
             return;
 
-        Block currentBlock = world.getType(position).getBlock();
-
-        if (((WChest) chest).isRemoved() || (currentBlock != Blocks.CHEST && currentBlock != Blocks.TRAPPED_CHEST)) {
+        if (((WChest) chest).isRemoved() || ((WChest) chest).getContainerMaterial() !=
+                chest.getLocation().getBlock().getType()) {
             world.b(this);
             return;
         }
@@ -354,4 +363,3 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
 }
-

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/NMSInventoryImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/NMSInventoryImpl.java
@@ -42,7 +42,7 @@ public final class NMSInventoryImpl implements NMSInventory {
 
         TileEntityWildChest tileEntityWildChest;
 
-        if (tileEntity instanceof TileEntityWildChest) {
+        if (tileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) tileEntity).isOwner(chest)) {
             tileEntityWildChest = (TileEntityWildChest) tileEntity;
             ((WChest) chest).setTileEntityContainer(tileEntityWildChest);
         } else {
@@ -58,7 +58,7 @@ public final class NMSInventoryImpl implements NMSInventory {
         World world = ((CraftWorld) loc.getWorld()).getHandle();
         BlockPosition blockPosition = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
         TileEntity currentTileEntity = world.getTileEntity(blockPosition);
-        if (currentTileEntity instanceof TileEntityWildChest)
+        if (currentTileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) currentTileEntity).isOwner(chest))
             world.removeTileEntity(blockPosition);
     }
 

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/inventory/TileEntityWildChest.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_16_R3/inventory/TileEntityWildChest.java
@@ -71,6 +71,16 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
     @Override
+    public boolean isOwner(Chest chest) {
+        return this.chest == chest;
+    }
+
+    @Override
+    public void closeContainer(HumanEntity humanEntity) {
+        closeContainer(((CraftHumanEntity) humanEntity).getHandle());
+    }
+
+    @Override
     protected NonNullList<ItemStack> f() {
         return getContents();
     }
@@ -200,9 +210,8 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
         if (--currentCooldown >= 0)
             return;
 
-        Block currentBlock = world.getType(position).getBlock();
-
-        if (((WChest) chest).isRemoved() || (currentBlock != Blocks.CHEST && currentBlock != Blocks.TRAPPED_CHEST)) {
+        if (((WChest) chest).isRemoved() || ((WChest) chest).getContainerMaterial() !=
+                chest.getLocation().getBlock().getType()) {
             world.removeTileEntity(position);
             return;
         }
@@ -330,4 +339,3 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
 }
-

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/NMSInventoryImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/NMSInventoryImpl.java
@@ -43,7 +43,7 @@ public final class NMSInventoryImpl implements NMSInventory {
 
         TileEntityWildChest tileEntityWildChest;
 
-        if (tileEntity instanceof TileEntityWildChest) {
+        if (tileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) tileEntity).isOwner(chest)) {
             tileEntityWildChest = (TileEntityWildChest) tileEntity;
             ((WChest) chest).setTileEntityContainer(tileEntityWildChest);
         } else {
@@ -59,7 +59,7 @@ public final class NMSInventoryImpl implements NMSInventory {
         World world = ((CraftWorld) loc.getWorld()).getHandle();
         BlockPosition blockPosition = new BlockPosition(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ());
         TileEntity currentTileEntity = world.getTileEntity(blockPosition);
-        if (currentTileEntity instanceof TileEntityWildChest)
+        if (currentTileEntity instanceof TileEntityWildChest && ((TileEntityWildChest) currentTileEntity).isOwner(chest))
             world.t(blockPosition);
     }
 

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/inventory/TileEntityWildChest.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildchests/nms/v1_8_R3/inventory/TileEntityWildChest.java
@@ -68,6 +68,16 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
     @Override
+    public boolean isOwner(Chest chest) {
+        return this.chest == chest;
+    }
+
+    @Override
+    public void closeContainer(HumanEntity humanEntity) {
+        closeContainer(((CraftHumanEntity) humanEntity).getHandle());
+    }
+
+    @Override
     public void setItem(int i, ItemStack itemStack) {
         ((WChest) chest).setItem(i, new WildContainerItemImpl(itemStack));
     }
@@ -204,9 +214,8 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
         if (--currentCooldown >= 0)
             return;
 
-        Block currentBlock = world.getType(position).getBlock();
-
-        if (((WChest) chest).isRemoved() || (currentBlock != Blocks.CHEST && currentBlock != Blocks.TRAPPED_CHEST)) {
+        if (((WChest) chest).isRemoved() || ((WChest) chest).getContainerMaterial() !=
+                chest.getLocation().getBlock().getType()) {
             world.t(position);
             return;
         }
@@ -363,4 +372,3 @@ public class TileEntityWildChest extends TileEntityChest implements IWorldInvent
     }
 
 }
-

--- a/src/main/java/com/bgsoftware/wildchests/command/commands/CommandLink.java
+++ b/src/main/java/com/bgsoftware/wildchests/command/commands/CommandLink.java
@@ -6,7 +6,6 @@ import com.bgsoftware.wildchests.api.objects.chests.Chest;
 import com.bgsoftware.wildchests.api.objects.chests.LinkedChest;
 import com.bgsoftware.wildchests.command.ICommand;
 import com.bgsoftware.wildchests.scheduler.Scheduler;
-import com.bgsoftware.wildchests.utils.ChestUtils;
 import com.bgsoftware.wildchests.utils.LinkedChestInteractEvent;
 import com.bgsoftware.wildchests.utils.LocationUtils;
 import org.bukkit.Bukkit;
@@ -84,7 +83,7 @@ public final class CommandLink implements ICommand {
 
         Block targetBlock = player.getTargetBlock(TRANSPARENT_TYPES, 5);
 
-        if (targetBlock == null || !ChestUtils.isChest(targetBlock.getType())) {
+        if (targetBlock == null || plugin.getChestsManager().getChest(targetBlock.getLocation()) == null) {
             Locale.INVALID_BLOCK_CHEST.send(player);
             return;
         }

--- a/src/main/java/com/bgsoftware/wildchests/database/DBSession.java
+++ b/src/main/java/com/bgsoftware/wildchests/database/DBSession.java
@@ -91,6 +91,17 @@ public class DBSession {
             globalSession.modifyColumnType(tableName, columnName, newType, QueryResult.EMPTY_VOID_QUERY_RESULT);
     }
 
+    public static boolean addColumn(String tableName, String columnName, String type) {
+        if (!isReady())
+            return false;
+
+        boolean[] added = {false};
+        globalSession.addColumn(tableName, columnName, type, new QueryResult<Void>()
+                .onSuccess(ignored -> added[0] = true)
+                .onFail(error -> WildChestsPlugin.log("Couldn't add column " + columnName + " to " + tableName + ": " + error.getMessage())));
+        return added[0];
+    }
+
     public static void close() {
         if (isReady()) {
             DatabaseTransactionsExecutor.stopActiveExecutors();

--- a/src/main/java/com/bgsoftware/wildchests/handlers/ChestsHandler.java
+++ b/src/main/java/com/bgsoftware/wildchests/handlers/ChestsHandler.java
@@ -71,7 +71,7 @@ public final class ChestsHandler implements ChestsManager {
 
     @Override
     public Chest addChest(UUID placer, Location location, ChestData chestData) {
-        WChest chest = createChestInternal(placer, location, chestData);
+        WChest chest = createChestInternal(placer, location, chestData, chestData.getContainerMaterial());
         plugin.getDataHandler().insertChest(chest);
         Scheduler.runTask(location, () -> plugin.getNMSInventory().updateTileEntity(chest));
         return chest;
@@ -213,7 +213,7 @@ public final class ChestsHandler implements ChestsManager {
         Location location = new Location(world, blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
 
 
-        if (Scheduler.isScheduledForRegion(location) && !ChestUtils.isChest(location.getBlock().getType())) {
+        if (Scheduler.isScheduledForRegion(location) && location.getBlock().getType() != ((WChest) chest).getContainerMaterial()) {
             removeChest(chest);
             return null;
         }
@@ -231,18 +231,18 @@ public final class ChestsHandler implements ChestsManager {
             unloadedChests.values().forEach(this::loadChestInternal);
     }
 
-    private WChest createChestInternal(UUID placer, Location location, ChestData chestData) {
+    private WChest createChestInternal(UUID placer, Location location, ChestData chestData, Material containerMaterial) {
         WChest chest;
 
         switch (chestData.getChestType()) {
             case CHEST:
-                chest = new WRegularChest(placer, location, chestData);
+                chest = new WRegularChest(placer, location, chestData, containerMaterial);
                 break;
             case LINKED_CHEST:
-                chest = new WLinkedChest(placer, location, chestData);
+                chest = new WLinkedChest(placer, location, chestData, containerMaterial);
                 break;
             case STORAGE_UNIT:
-                chest = new WStorageChest(placer, location, chestData);
+                chest = new WStorageChest(placer, location, chestData, containerMaterial);
                 break;
             default:
                 throw new IllegalArgumentException("Invalid chest at " + location);
@@ -266,8 +266,19 @@ public final class ChestsHandler implements ChestsManager {
         Location location = new Location(world, unloadedChest.position.getX(),
                 unloadedChest.position.getY(), unloadedChest.position.getZ());
 
-        WChest chest = createChestInternal(unloadedChest.placer, location, unloadedChest.chestData);
+        Material containerMaterial = unloadedChest.containerMaterial;
+        if (containerMaterial == null) {
+            // Legacy database rows did not store the appearance. Preserve the block already in the
+            // world when possible instead of applying the current configuration retroactively.
+            Material blockType = location.getBlock().getType();
+            containerMaterial = plugin.getNMSInventory().isContainerMaterialSupported(blockType) ? blockType : Material.CHEST;
+        }
+
+        WChest chest = createChestInternal(unloadedChest.placer, location, unloadedChest.chestData, containerMaterial);
         chest.loadFromData(unloadedChest);
+
+        if (unloadedChest.containerMaterial == null)
+            plugin.getDataHandler().saveContainerMaterial(chest);
 
         return chest;
     }
@@ -277,11 +288,14 @@ public final class ChestsHandler implements ChestsManager {
         public final UUID placer;
         public final BlockPosition position;
         public final ChestData chestData;
+        @Nullable
+        public final Material containerMaterial;
 
-        public UnloadedChest(UUID placer, BlockPosition position, ChestData chestData) {
+        public UnloadedChest(UUID placer, BlockPosition position, ChestData chestData, @Nullable Material containerMaterial) {
             this.placer = placer;
             this.position = position;
             this.chestData = chestData;
+            this.containerMaterial = containerMaterial;
         }
 
     }
@@ -292,9 +306,9 @@ public final class ChestsHandler implements ChestsManager {
         public final BigInteger amount;
         public final BigInteger maxAmount;
 
-        public UnloadedStorageUnit(UUID placer, BlockPosition position, ChestData chestData,
+        public UnloadedStorageUnit(UUID placer, BlockPosition position, ChestData chestData, @Nullable Material containerMaterial,
                                    ItemStack itemStack, BigInteger amount, BigInteger maxAmount) {
-            super(placer, position, chestData);
+            super(placer, position, chestData, containerMaterial);
             this.itemStack = itemStack;
             this.amount = amount;
             this.maxAmount = maxAmount;
@@ -309,9 +323,9 @@ public final class ChestsHandler implements ChestsManager {
         public final Location linkedChest;
         public boolean executeUpdate;
 
-        public UnloadedRegularChest(UUID placer, BlockPosition position, ChestData chestData,
+        public UnloadedRegularChest(UUID placer, BlockPosition position, ChestData chestData, @Nullable Material containerMaterial,
                                     InventoryHolder[] inventories, @Nullable Location linkedChest, boolean executeUpdate) {
-            super(placer, position, chestData);
+            super(placer, position, chestData, containerMaterial);
             this.inventories = inventories;
             this.linkedChest = linkedChest;
             this.executeUpdate = executeUpdate;

--- a/src/main/java/com/bgsoftware/wildchests/handlers/DataHandler.java
+++ b/src/main/java/com/bgsoftware/wildchests/handlers/DataHandler.java
@@ -25,6 +25,7 @@ import com.bgsoftware.wildchests.utils.LocationUtils;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.inventory.Inventory;
@@ -41,6 +42,7 @@ import java.math.BigInteger;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.UUID;
@@ -142,10 +144,11 @@ public final class DataHandler {
         if (chest instanceof StorageChest) {
             WStorageChest storageChest = (WStorageChest) chest;
             DBSession.execute(new InsertSQLDatabaseTransaction("storage_units",
-                    Arrays.asList("location", "placer", "chest_data", "item", "amount", "max_amount"))
+                    Arrays.asList("location", "placer", "chest_data", "container", "item", "amount", "max_amount"))
                     .bindObject(serializeLocationInternal(chest.getLocation()))
                     .bindObject(chest.getPlacer().toString())
                     .bindObject(chest.getData().getName())
+                    .bindObject(((WChest) chest).getContainerMaterial().name())
                     .bindObject(serializeItemInternal(storageChest.getItemStackUnsafe()))
                     .bindObject(storageChest.getAmount().toString())
                     .bindObject(storageChest.getMaxAmount().toString())
@@ -154,19 +157,21 @@ public final class DataHandler {
             WLinkedChest linkedChest = (WLinkedChest) chest;
             boolean isLinkedIntoChest = linkedChest.isLinkedIntoChest();
             DBSession.execute(new InsertSQLDatabaseTransaction("linked_chests",
-                    Arrays.asList("location", "placer", "chest_data", "inventories", "linked_chest"))
+                    Arrays.asList("location", "placer", "chest_data", "container", "inventories", "linked_chest"))
                     .bindObject(serializeLocationInternal(chest.getLocation()))
                     .bindObject(chest.getPlacer().toString())
                     .bindObject(chest.getData().getName())
+                    .bindObject(((WChest) chest).getContainerMaterial().name())
                     .bindObject(serializeInventoriesInternal(isLinkedIntoChest ? null : linkedChest.getPages()))
                     .bindObject(serializeLocationInternal(isLinkedIntoChest ? linkedChest.getLinkedChest().getLocation() : null))
             );
         } else {
             DBSession.execute(new InsertSQLDatabaseTransaction("chests",
-                    Arrays.asList("location", "placer", "chest_data", "inventories"))
+                    Arrays.asList("location", "placer", "chest_data", "container", "inventories"))
                     .bindObject(serializeLocationInternal(chest.getLocation()))
                     .bindObject(chest.getPlacer().toString())
                     .bindObject(chest.getData().getName())
+                    .bindObject(((WChest) chest).getContainerMaterial().name())
                     .bindObject(serializeInventoriesInternal(chest.getPages()))
             );
         }
@@ -227,17 +232,20 @@ public final class DataHandler {
                 new Column("location", "LONG_UNIQUE_TEXT PRIMARY KEY"),
                 new Column("placer", "UUID"),
                 new Column("chest_data", "TEXT"),
+                new Column("container", "TEXT"),
                 new Column("inventories", "LONGTEXT"));
         DBSession.createTable("linked_chests",
                 new Column("location", "LONG_UNIQUE_TEXT PRIMARY KEY"),
                 new Column("placer", "UUID"),
                 new Column("chest_data", "TEXT"),
+                new Column("container", "TEXT"),
                 new Column("inventories", "LONGTEXT"),
                 new Column("linked_chest", "LONG_UNIQUE_TEXT"));
         DBSession.createTable("storage_units",
                 new Column("location", "LONG_UNIQUE_TEXT PRIMARY KEY"),
                 new Column("placer", "UUID"),
                 new Column("chest_data", "TEXT"),
+                new Column("container", "TEXT"),
                 new Column("item", "TEXT"),
                 new Column("amount", "TEXT"),
                 new Column("max_amount", "TEXT"));
@@ -247,6 +255,9 @@ public final class DataHandler {
 
         DBSession.modifyColumnType("chests", "inventories", "LONGTEXT");
         DBSession.modifyColumnType("linked_chests", "inventories", "LONGTEXT");
+        addColumnIfMissing("chests", "container", "TEXT");
+        addColumnIfMissing("linked_chests", "container", "TEXT");
+        addColumnIfMissing("storage_units", "container", "TEXT");
 
         List<IDatabaseTransaction> transactionsToExecute = new LinkedList<>();
 
@@ -289,6 +300,16 @@ public final class DataHandler {
                 continue;
             }
 
+            // Rows created before container appearances were introduced have no value here. Their
+            // material is resolved from the placed block when the chunk is first loaded.
+            String containerMaterialName = resultSet.getString("container");
+            Material containerMaterial = getContainerMaterial(containerMaterialName);
+            if (containerMaterialName != null && !containerMaterialName.isEmpty() && containerMaterial == null) {
+                WildChestsPlugin.log("Couldn't load the location " + stringLocation);
+                WildChestsPlugin.log("The stored container material `" + containerMaterialName + "` is not supported.");
+                continue;
+            }
+
             BlockPosition position = BlockPosition.deserialize(stringLocation);
 
             if (plugin.getSettings().invalidWorldDelete) {
@@ -308,7 +329,7 @@ public final class DataHandler {
                 String item = resultSet.getString("item");
                 String amount = resultSet.getString("amount");
                 String maxAmount = resultSet.getString("max_amount");
-                unloadedChest = new ChestsHandler.UnloadedStorageUnit(placer, position, chestData,
+                unloadedChest = new ChestsHandler.UnloadedStorageUnit(placer, position, chestData, containerMaterial,
                         plugin.getNMSAdapter().deserialzeItem(item), new BigInteger(amount), new BigInteger(maxAmount));
             } else {
                 String inventories = resultSet.getString("inventories");
@@ -320,7 +341,7 @@ public final class DataHandler {
 
                 boolean executeUpdate = !inventories.isEmpty() && inventories.toCharArray()[0] != '*';
 
-                unloadedChest = new ChestsHandler.UnloadedRegularChest(placer, position, chestData,
+                unloadedChest = new ChestsHandler.UnloadedRegularChest(placer, position, chestData, containerMaterial,
                         plugin.getNMSAdapter().deserialze(inventories), linkedChest, executeUpdate);
             }
 
@@ -329,6 +350,54 @@ public final class DataHandler {
 
         if (calledDeleteTransaction)
             transactionsToExecute.add(deleteNullWorldTransaction);
+
+    }
+
+    private void addColumnIfMissing(String tableName, String columnName, String columnType) {
+        // DatabaseBridge invokes these schema callbacks synchronously, so inspect the schema before
+        // attempting the migration and fail startup if it cannot be completed safely.
+        boolean[] exists = {false};
+        boolean[] queried = {false};
+        DBSession.select(tableName, " LIMIT 0", new QueryResult<ResultSet>().onSuccess(resultSet -> {
+            queried[0] = true;
+            try {
+                resultSet.findColumn(columnName);
+                exists[0] = true;
+            } catch (SQLException ignored) {
+            }
+        }).onFail(error -> WildChestsPlugin.log("Couldn't inspect table " + tableName + ": " + error.getMessage())));
+
+        if (!queried[0])
+            throw new IllegalStateException("Couldn't inspect table " + tableName + " before migration.");
+
+        if (!exists[0] && !DBSession.addColumn(tableName, columnName, columnType))
+            throw new IllegalStateException("Couldn't add column " + columnName + " to table " + tableName + ".");
+    }
+
+    @Nullable
+    private Material getContainerMaterial(@Nullable String materialName) {
+        if (materialName == null || materialName.isEmpty())
+            return null;
+
+        Material material = Material.matchMaterial(materialName);
+        return material != null && plugin.getNMSInventory().isContainerMaterialSupported(material) ? material : null;
+    }
+
+    public void saveContainerMaterial(WChest chest) {
+        String tableName = "chests";
+        if (chest instanceof StorageChest) {
+            tableName = "storage_units";
+        } else if (chest instanceof LinkedChest) {
+            tableName = "linked_chests";
+        }
+
+        // Persist the material inferred for legacy rows so later config changes cannot alter an
+        // already placed chest's appearance.
+        DBSession.execute(new UpdateSQLDatabaseTransaction(tableName,
+                Collections.singletonList("container"), Collections.singletonList("location"))
+                .bindObject(chest.getContainerMaterial().name())
+                .bindObject(serializeLocationInternal(chest.getLocation()))
+        );
     }
 
     private void loadOldDatabase() {

--- a/src/main/java/com/bgsoftware/wildchests/handlers/SettingsHandler.java
+++ b/src/main/java/com/bgsoftware/wildchests/handlers/SettingsHandler.java
@@ -171,7 +171,13 @@ public final class SettingsHandler {
             return null;
         }
 
-        ItemStack itemStack = new ItemStack(Material.CHEST);
+        Material containerMaterial = Material.matchMaterial(section.getString("container", "CHEST").toUpperCase(Locale.ENGLISH));
+        if (!plugin.getNMSInventory().isContainerMaterialSupported(containerMaterial)) {
+            WildChestsPlugin.log("Found an invalid or unsupported container material for " + chestName + " - skipping...");
+            return null;
+        }
+
+        ItemStack itemStack = new ItemStack(containerMaterial);
         ItemMeta itemMeta = itemStack.getItemMeta();
 
         if (section.contains("item.name")) {
@@ -190,6 +196,7 @@ public final class SettingsHandler {
         itemStack.setItemMeta(itemMeta);
 
         ChestData chestData = new WChestData(chestName, plugin.getNMSAdapter().setChestType(itemStack, chestType), chestType);
+        chestData.setContainerMaterial(containerMaterial);
 
         if (section.contains("size")) {
             int rows = section.getInt("size");

--- a/src/main/java/com/bgsoftware/wildchests/listeners/BlockListener.java
+++ b/src/main/java/com/bgsoftware/wildchests/listeners/BlockListener.java
@@ -40,7 +40,9 @@ public final class BlockListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
     public void onChestPlaceNearAnother(BlockPlaceEvent e) {
-        if (!ChestUtils.isChest(e.getBlockPlaced().getType()))
+        ChestData chestData = plugin.getChestsManager().getChestData(e.getItemInHand());
+
+        if (chestData == null || !ChestUtils.isChest(e.getBlockPlaced().getType()))
             return;
 
         boolean hasNearbyChest = false;
@@ -57,23 +59,15 @@ public final class BlockListener implements Listener {
             }
         }
 
-        ChestData chestData = plugin.getChestsManager().getChestData(e.getItemInHand());
-
-        if (chestData == null)
-            return;
-
         if (hasNearbyChest)
             e.setCancelled(true);
     }
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onChestPlace(BlockPlaceEvent e) {
-        if (!ChestUtils.isChest(e.getBlockPlaced().getType()))
-            return;
-
         ChestData chestData = plugin.getChestsManager().getChestData(e.getItemInHand());
 
-        if (chestData == null)
+        if (chestData == null || e.getBlockPlaced().getType() != chestData.getContainerMaterial())
             return;
 
         Chest chest = plugin.getChestsManager().addChest(e.getPlayer().getUniqueId(), e.getBlockPlaced().getLocation(), chestData);

--- a/src/main/java/com/bgsoftware/wildchests/listeners/ChunksListener.java
+++ b/src/main/java/com/bgsoftware/wildchests/listeners/ChunksListener.java
@@ -3,7 +3,6 @@ package com.bgsoftware.wildchests.listeners;
 import com.bgsoftware.wildchests.WildChestsPlugin;
 import com.bgsoftware.wildchests.objects.chests.WChest;
 import com.bgsoftware.wildchests.scheduler.Scheduler;
-import com.bgsoftware.wildchests.utils.ChestUtils;
 import org.bukkit.Chunk;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -45,7 +44,7 @@ public final class ChunksListener implements Listener {
         plugin.getChestsManager().getChests(chunk).forEach(chest -> {
             Location location = chest.getLocation();
             Material blockType = location.getBlock().getType();
-            if (!ChestUtils.isChest(blockType)) {
+            if (blockType != ((WChest) chest).getContainerMaterial()) {
                 WildChestsPlugin.log("Loading chunk " + chunk.getX() + ", " + chunk.getX() + " but found a chest not " +
                         "associated with a chest block but " + blockType + " at " + location.getWorld().getName() + ", " +
                         location.getBlockX() + ", " + location.getBlockY() + ", " + location.getBlockZ());

--- a/src/main/java/com/bgsoftware/wildchests/listeners/InventoryListener.java
+++ b/src/main/java/com/bgsoftware/wildchests/listeners/InventoryListener.java
@@ -9,7 +9,6 @@ import com.bgsoftware.wildchests.objects.Materials;
 import com.bgsoftware.wildchests.objects.chests.WChest;
 import com.bgsoftware.wildchests.objects.inventory.CraftWildInventory;
 import com.bgsoftware.wildchests.scheduler.Scheduler;
-import com.bgsoftware.wildchests.utils.ChestUtils;
 import com.bgsoftware.wildchests.utils.LinkedChestInteractEvent;
 import com.google.common.collect.Maps;
 import org.bukkit.Bukkit;
@@ -74,8 +73,7 @@ public final class InventoryListener implements Listener {
 
     @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
     public void onChestOpen(PlayerInteractEvent e) {
-        if (e instanceof LinkedChestInteractEvent || e.getAction() != Action.RIGHT_CLICK_BLOCK ||
-                !ChestUtils.isChest(e.getClickedBlock().getType()))
+        if (e instanceof LinkedChestInteractEvent || e.getAction() != Action.RIGHT_CLICK_BLOCK)
             return;
 
         if (buyNewPage.containsKey(e.getPlayer().getUniqueId())) {

--- a/src/main/java/com/bgsoftware/wildchests/nms/NMSInventory.java
+++ b/src/main/java/com/bgsoftware/wildchests/nms/NMSInventory.java
@@ -3,10 +3,15 @@ package com.bgsoftware.wildchests.nms;
 import com.bgsoftware.wildchests.api.objects.chests.Chest;
 import com.bgsoftware.wildchests.objects.inventory.CraftWildInventory;
 import com.bgsoftware.wildchests.objects.inventory.WildContainerItem;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
 public interface NMSInventory {
+
+    default boolean isContainerMaterialSupported(Material material) {
+        return material == Material.CHEST || material == Material.TRAPPED_CHEST;
+    }
 
     void updateTileEntity(Chest chest);
 

--- a/src/main/java/com/bgsoftware/wildchests/objects/chests/WChest.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/chests/WChest.java
@@ -55,15 +55,18 @@ public abstract class WChest implements Chest {
     protected final UUID placer;
     protected final BlockPosition blockPosition;
     protected final ChestData chestData;
+    // The selected material belongs to this placed chest, not to its mutable config definition.
+    protected final Material containerMaterial;
 
     protected TileEntityContainer tileEntityContainer;
     protected boolean removed = false;
 
-    protected WChest(UUID placer, Location location, ChestData chestData) {
+    protected WChest(UUID placer, Location location, ChestData chestData, Material containerMaterial) {
         this.placer = placer;
         this.blockPosition = new BlockPosition(location.getWorld().getName(),
                 location.getBlockX(), location.getBlockY(), location.getBlockZ());
         this.chestData = chestData;
+        this.containerMaterial = containerMaterial;
     }
 
     /* CHEST RELATED METHODS */
@@ -82,6 +85,10 @@ public abstract class WChest implements Chest {
     @Override
     public ChestData getData() {
         return chestData;
+    }
+
+    public Material getContainerMaterial() {
+        return containerMaterial;
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/wildchests/objects/chests/WLinkedChest.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/chests/WLinkedChest.java
@@ -10,6 +10,7 @@ import com.bgsoftware.wildchests.utils.LocationUtils;
 import com.bgsoftware.wildchests.utils.SyncedArray;
 import com.google.common.base.Preconditions;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryCloseEvent;
@@ -28,8 +29,8 @@ public final class WLinkedChest extends WRegularChest implements LinkedChest {
     @Nullable
     private LinkedChestsChain linkedChestsChain;
 
-    public WLinkedChest(UUID placer, Location location, ChestData chestData) {
-        super(placer, location, chestData);
+    public WLinkedChest(UUID placer, Location location, ChestData chestData, Material containerMaterial) {
+        super(placer, location, chestData, containerMaterial);
         this.linkedChestsChain = null;
     }
 

--- a/src/main/java/com/bgsoftware/wildchests/objects/chests/WRegularChest.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/chests/WRegularChest.java
@@ -10,6 +10,7 @@ import com.bgsoftware.wildchests.objects.inventory.InventoryHolder;
 import com.bgsoftware.wildchests.objects.inventory.WildContainerItem;
 import com.bgsoftware.wildchests.utils.SyncedArray;
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.inventory.Inventory;
 
 import java.util.ArrayList;
@@ -21,8 +22,8 @@ public class WRegularChest extends WChest implements RegularChest {
 
     protected SyncedArray<CraftWildInventory> inventories;
 
-    public WRegularChest(UUID placer, Location location, ChestData chestData) {
-        super(placer, location, chestData);
+    public WRegularChest(UUID placer, Location location, ChestData chestData, Material containerMaterial) {
+        super(placer, location, chestData, containerMaterial);
         initContainer(chestData);
     }
 

--- a/src/main/java/com/bgsoftware/wildchests/objects/chests/WStorageChest.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/chests/WStorageChest.java
@@ -48,8 +48,8 @@ public final class WStorageChest extends WChest implements StorageChest {
     private Integer takeItemCheckSlot = null;
     private volatile int titleUpdateToken = 0;
 
-    public WStorageChest(UUID placer, Location location, ChestData chestData) {
-        super(placer, location, chestData);
+    public WStorageChest(UUID placer, Location location, ChestData chestData, Material containerMaterial) {
+        super(placer, location, chestData, containerMaterial);
         maxAmount = chestData.getStorageUnitMaxAmount();
         inventory = plugin.getNMSInventory().createInventory(this, INVENTORY_SIZE,
                 chestData.getTitle(1).replace("{0}", amount + ""), 0);

--- a/src/main/java/com/bgsoftware/wildchests/objects/containers/TileEntityContainer.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/containers/TileEntityContainer.java
@@ -1,10 +1,18 @@
 package com.bgsoftware.wildchests.objects.containers;
 
+import com.bgsoftware.wildchests.api.objects.chests.Chest;
 import org.bukkit.entity.HumanEntity;
 
 import java.util.List;
 
 public interface TileEntityContainer {
+
+    /**
+     * Check whether this tile entity was created for the given chest instance.
+     */
+    boolean isOwner(Chest chest);
+
+    void closeContainer(HumanEntity humanEntity);
 
     int getViewingCount();
 

--- a/src/main/java/com/bgsoftware/wildchests/objects/data/WChestData.java
+++ b/src/main/java/com/bgsoftware/wildchests/objects/data/WChestData.java
@@ -10,6 +10,7 @@ import com.bgsoftware.wildchests.key.KeySet;
 import com.bgsoftware.wildchests.utils.RecipeUtils;
 import com.google.common.collect.Iterators;
 import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.Recipe;
 
@@ -29,6 +30,7 @@ public final class WChestData implements ChestData {
     private final String chestType;
 
     private ItemStack itemStack;
+    private Material containerMaterial;
     private int defaultSize;
     private String defaultTitle;
     private boolean sellMode;
@@ -50,6 +52,7 @@ public final class WChestData implements ChestData {
     public WChestData(String name, ItemStack itemStack, ChestType chestType) {
         this.name = name;
         this.itemStack = itemStack;
+        this.containerMaterial = Material.CHEST;
         this.chestType = chestType.name();
         this.defaultSize = 9 * 3;
         this.defaultTitle = "Chest";
@@ -85,6 +88,11 @@ public final class WChestData implements ChestData {
     @Override
     public ChestType getChestType() {
         return ChestType.valueOf(chestType);
+    }
+
+    @Override
+    public Material getContainerMaterial() {
+        return containerMaterial;
     }
 
     @Override
@@ -211,6 +219,11 @@ public final class WChestData implements ChestData {
     }
 
     @Override
+    public void setContainerMaterial(Material containerMaterial) {
+        this.containerMaterial = containerMaterial;
+    }
+
+    @Override
     public void setDefaultTitle(String title) {
         this.defaultTitle = title;
     }
@@ -309,6 +322,7 @@ public final class WChestData implements ChestData {
 
     public void loadFromData(WChestData chestData) {
         this.itemStack = chestData.itemStack;
+        this.containerMaterial = chestData.containerMaterial;
         this.defaultSize = chestData.defaultSize;
         this.defaultTitle = chestData.defaultTitle;
         this.sellMode = chestData.sellMode;

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -103,6 +103,9 @@ max-stacks-on-drop: -1
 # pages.<#>: Section that handles all settings for a specific page
 # pages.<#>.price: Price for upgrading to that page (DOUBLE) [REQUIRED]
 # pages.<#>.title: Custom title for that page.
+# container: The block used to place the chest (CHEST, TRAPPED_CHEST, or BARREL; default: CHEST).
+#            BARREL requires Minecraft 1.17 or newer.
+#            Existing chests keep the container material selected when they were placed.
 # item.name: Custom name for the chest (STRING)
 # item.lore: Custom lore for the chest (LIST)
 # multiplier: Money multiplier for sell chests. (DOUBLE)
@@ -119,6 +122,7 @@ max-stacks-on-drop: -1
 chests:
   linked_chest:
     chest-mode: LINKED_CHEST
+    container: CHEST
     title: Linked Chest
     item:
       name: '&6Linked Chest &7(Place to active)'
@@ -126,6 +130,7 @@ chests:
       - CRIT
   large_chest:
     chest-mode: CHEST
+    container: CHEST
     size: 6
     item:
       name: '&aLarge Chest &7(Place to active)'
@@ -147,6 +152,7 @@ chests:
       - TOTEM
   sell_chest:
     chest-mode: CHEST
+    container: CHEST
     size: 6
     title: Drop your items here to sell them.
     item:
@@ -156,6 +162,7 @@ chests:
       - SPELL_WITCH
   auto_crafter:
     chest-mode: CHEST
+    container: CHEST
     size: 6
     title: Drop your items here to auto-craft them.
     item:
@@ -166,6 +173,7 @@ chests:
       - LANDING_LAVA
   storage_unit:
     chest-mode: STORAGE_UNIT
+    container: CHEST
     size: 3
     title: Storage Unit {0}
     item:
@@ -174,6 +182,7 @@ chests:
       - CRIT_MAGIC
   chunk_collector:
     chest-mode: CHEST
+    container: CHEST
     size: 6
     title: Chunk Collector
     item:


### PR DESCRIPTION
Adds a container setting to chest definitions, allowing WildChests to be placed as a normal chest, trapped chest, or barrel (barrels require 1.17+):
- Persists each placed chest’s selected container material across restarts.
- Supports regular, linked, and storage-unit chests.
- Automatically migrates existing database tables with a container column.
- Preserves legacy chests’ current placed block appearance and saves it after first load.
- Validates configured materials and prevents mismatched block placements from becoming managed chests.
- Updates custom tile entities and inventory handling for the supported container types.